### PR TITLE
Add detection for Zoom & RingCentral (CVE-2019–13450)

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -86,6 +86,16 @@ const services = [
         name: 'Dropbox (17600)',
     },
     {
+        url: 'http://127.0.0.1:19421/app_check?action=checkVersion',
+        name: 'Zoom Video Conferencing (CVE-2019–13450, 19421)',
+        type: 'img',
+    },
+    {
+        url: 'http://127.0.0.1:19424/app_check?action=checkVersion',
+        name: 'RingCentral Video Conferencing (CVE-2019–13450, 19424)',
+        type: 'img',
+    },
+    {
         url: 'http://127.0.0.1:19999',
         name: 'Netdata (19999)',
     },


### PR DESCRIPTION
See 

- https://medium.com/@jonathan.leitschuh/zoom-zero-day-4-million-webcams-maybe-an-rce-just-get-them-to-visit-your-website-ac75c83f4ef5
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-13450
- https://news.ycombinator.com/item?id=20387298 (For the RingCentral port)

Unfortunately, I cannot test this since I don't have a Mac or the affected software :/ ;)
