### PR TITLE
 Add another Fritz!Box url

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -139,6 +139,11 @@ const services = [
         type: 'img',
     },
     {
+        url: 'http://fritz.box/css/rd/logos/logo_fritzDiamond.svg',
+        name: 'AVM FRITZ!Box (http://fritz.box)',
+        type: 'img',
+    },
+    {
         url: 'https://freedombox/plinth/static/theme/img/freedombox-logo-32px.png',
         name: 'FreedomBox',
         type: 'img',


### PR DESCRIPTION
The implemented url works with the current firmware version of the Fritz!Box 7490.
The url, which has already been implemented in PR #8 does not work with the popular Fritz!Box 7490 router (and the current firmware version).

I assume, that the assertion is true for a variety of recent Fritz!Box models, since their firmwares do not differ much considering the web server.